### PR TITLE
feat: Add moltbot deployment to Hypercore

### DIFF
--- a/deployments/moltbot-cloud/Dockerfile
+++ b/deployments/moltbot-cloud/Dockerfile
@@ -1,0 +1,69 @@
+# Clawdbot VM Image (Built from Source)
+# Full Clawdbot gateway running in Hypercore microVMs
+# Usage: hypercore spawn clawdbot/clawdbot-vm:latest
+
+FROM node:22-bookworm AS builder
+
+# Install pnpm
+RUN npm install -g pnpm
+
+# Copy source code
+WORKDIR /build
+COPY . .
+
+# Install and build (including UI)
+RUN pnpm install --frozen-lockfile
+RUN pnpm build
+RUN pnpm ui:build
+
+# Create tarball for global install
+RUN pnpm pack
+
+# Runtime image - use node base for native module compatibility
+FROM node:22-bookworm-slim
+
+# Install base packages and build tools for native modules
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    unzip \
+    ca-certificates \
+    sudo \
+    build-essential \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy and install built clawdbot
+COPY --from=builder /build/*.tgz /tmp/clawdbot.tgz
+RUN npm install -g /tmp/clawdbot.tgz && rm /tmp/clawdbot.tgz
+
+# Create clawdbot user
+RUN useradd -m -s /bin/bash clawdbot && \
+    echo "clawdbot ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Switch to clawdbot user
+USER clawdbot
+WORKDIR /home/clawdbot
+ENV HOME=/home/clawdbot
+
+# Create config directory
+RUN mkdir -p /home/clawdbot/.clawdbot
+
+# Copy entrypoint script
+COPY --chown=clawdbot:clawdbot images/clawdbot-vm/entrypoint.sh /opt/entrypoint.sh
+RUN chmod +x /opt/entrypoint.sh
+
+# Expose gateway port
+EXPOSE 18789
+
+# Health check
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:18789/health || exit 1
+
+# Default environment
+ENV CLAWDBOT_PROVIDER=anthropic
+ENV CLAWDBOT_MODEL=claude-sonnet-4-20250514
+ENV CLAWDBOT_PORT=18789
+
+# Start Clawdbot gateway via entrypoint
+CMD ["/opt/entrypoint.sh"]

--- a/deployments/moltbot-cloud/entrypoint.sh
+++ b/deployments/moltbot-cloud/entrypoint.sh
@@ -6,9 +6,20 @@ set -e
 
 echo "Clawdbot Cloud: Starting..."
 
-# Generate a token if not provided
+# Generate a token if not provided (hex only for JSON safety)
 GATEWAY_TOKEN="${CLAWDBOT_GATEWAY_TOKEN:-$(openssl rand -hex 16)}"
+# Validate token is hex-safe (alphanumeric only, no special chars)
+if [[ ! "$GATEWAY_TOKEN" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "WARNING: Token contains special characters, generating safe token"
+  GATEWAY_TOKEN=$(openssl rand -hex 16)
+fi
+
+# Validate port is numeric
 GATEWAY_PORT="${CLAWDBOT_PORT:-18789}"
+if [[ ! "$GATEWAY_PORT" =~ ^[0-9]+$ ]]; then
+  echo "WARNING: Invalid port '$GATEWAY_PORT', using default 18789"
+  GATEWAY_PORT=18789
+fi
 
 # Create config directory
 mkdir -p ~/.clawdbot
@@ -28,8 +39,19 @@ cat > ~/.clawdbot/moltbot.json << EOF
       "dangerouslyDisableDeviceAuth": true
     }
   },
+  "auth": {
+    "profiles": {
+      "anthropic:default": {
+        "provider": "anthropic",
+        "mode": "api_key"
+      }
+    }
+  },
   "agents": {
     "defaults": {
+      "model": {
+        "primary": "anthropic/claude-sonnet-4-20250514"
+      },
       "workspace": "/home/clawdbot/workspace"
     }
   }
@@ -41,15 +63,61 @@ mkdir -p ~/workspace
 
 echo ""
 echo "╔════════════════════════════════════════════════════════════════╗"
-echo "║                    MOLTBOT CLOUD READY                        ║"
+echo "║                    CLAWDBOT CLOUD READY                        ║"
 echo "╚════════════════════════════════════════════════════════════════╝"
 echo ""
 echo "📋 Token: $GATEWAY_TOKEN"
 echo ""
 
-# Check API keys
+# Check API keys and create auth-profiles.json
 if [ -n "$ANTHROPIC_API_KEY" ]; then
   echo "ANTHROPIC_API_KEY is set (${#ANTHROPIC_API_KEY} chars)"
+
+  # Create auth-profiles directory
+  mkdir -p ~/.clawdbot/agents/main/agent
+
+  # Write auth-profiles.json with proper JSON escaping
+  if command -v jq &> /dev/null; then
+    # Use jq for safe JSON generation
+    jq -n \
+      --arg key "$ANTHROPIC_API_KEY" \
+      '{
+        version: 1,
+        profiles: {
+          "anthropic:default": {
+            type: "api_key",
+            provider: "anthropic",
+            key: $key
+          }
+        },
+        lastGood: {
+          anthropic: "anthropic:default"
+        }
+      }' > ~/.clawdbot/agents/main/agent/auth-profiles.json
+  else
+    # Fallback: validate key has no dangerous chars (Anthropic keys are base64-safe)
+    if [[ "$ANTHROPIC_API_KEY" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+      cat > ~/.clawdbot/agents/main/agent/auth-profiles.json << AUTHEOF
+{
+  "version": 1,
+  "profiles": {
+    "anthropic:default": {
+      "type": "api_key",
+      "provider": "anthropic",
+      "key": "${ANTHROPIC_API_KEY}"
+    }
+  },
+  "lastGood": {
+    "anthropic": "anthropic:default"
+  }
+}
+AUTHEOF
+    else
+      echo "ERROR: API key contains invalid characters"
+      exit 1
+    fi
+  fi
+  echo "Created auth-profiles.json"
 else
   echo "WARNING: ANTHROPIC_API_KEY is NOT set"
 fi

--- a/deployments/moltbot-cloud/entrypoint.sh
+++ b/deployments/moltbot-cloud/entrypoint.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Clawdbot Cloud Entrypoint
+# Fast startup by writing config directly instead of running multiple commands
+
+set -e
+
+echo "Clawdbot Cloud: Starting..."
+
+# Generate a token if not provided
+GATEWAY_TOKEN="${CLAWDBOT_GATEWAY_TOKEN:-$(openssl rand -hex 16)}"
+GATEWAY_PORT="${CLAWDBOT_PORT:-18789}"
+
+# Create config directory
+mkdir -p ~/.clawdbot
+
+# Write config to moltbot.json (the config file the gateway reads)
+cat > ~/.clawdbot/moltbot.json << EOF
+{
+  "gateway": {
+    "port": ${GATEWAY_PORT},
+    "mode": "local",
+    "bind": "lan",
+    "auth": {
+      "mode": "token",
+      "token": "${GATEWAY_TOKEN}"
+    },
+    "controlUi": {
+      "dangerouslyDisableDeviceAuth": true
+    }
+  },
+  "agents": {
+    "defaults": {
+      "workspace": "/home/clawdbot/workspace"
+    }
+  }
+}
+EOF
+
+# Create workspace directory
+mkdir -p ~/workspace
+
+echo ""
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║                    MOLTBOT CLOUD READY                        ║"
+echo "╚════════════════════════════════════════════════════════════════╝"
+echo ""
+echo "📋 Token: $GATEWAY_TOKEN"
+echo ""
+
+# Check API keys
+if [ -n "$ANTHROPIC_API_KEY" ]; then
+  echo "ANTHROPIC_API_KEY is set (${#ANTHROPIC_API_KEY} chars)"
+else
+  echo "WARNING: ANTHROPIC_API_KEY is NOT set"
+fi
+
+# Start the gateway
+exec moltbot gateway run --bind lan --port "${GATEWAY_PORT}"

--- a/pkg/containerd/repo.go
+++ b/pkg/containerd/repo.go
@@ -1,9 +1,14 @@
+// +build !darwin
+// +build linux
+
 package containerd
 
 import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -239,7 +244,7 @@ func (r *Repo) CreateContainer(ctx context.Context, opts CreateContainerOpts) (_
         "ipMasq": true,
         "ipam": {
           "type": "host-local",
-          "subnet": "192.168.127.0/24",
+          "subnet": "10.88.0.0/16",
           "resolvConf": "/etc/resolv.conf",
           "routes": [
             { "dst": "0.0.0.0/0" }
@@ -259,20 +264,31 @@ func (r *Repo) CreateContainer(ctx context.Context, opts CreateContainerOpts) (_
 		cniPlugins = append(cniPlugins, &libcni.NetworkConfig{Network: &types.NetConf{Type: "tc-redirect-tap"}, Bytes: []byte(tapConfig)})
 	}
 
-	_, err = libcni.NewCNIConfig([]string{"/opt/hypercore/bin", "/opt/cni/bin"}, nil).AddNetworkList(
-		namespaceCtx, &libcni.NetworkConfigList{
-			Name:       "hypercore-cni",
-			CNIVersion: "0.4.0",
-			Plugins:    cniPlugins,
-		}, &libcni.RuntimeConf{
-			ContainerID: containerID,
-			NetNS:       netNs.GetPath(),
-			IfName:      "eth0",
-		},
-	)
+	cniConfig := libcni.NewCNIConfig([]string{"/opt/hypercore/bin", "/opt/cni/bin"}, nil)
+	cniNetworkList := &libcni.NetworkConfigList{
+		Name:       "hypercore-cni",
+		CNIVersion: "0.4.0",
+		Plugins:    cniPlugins,
+	}
+	cniRuntimeConf := &libcni.RuntimeConf{
+		ContainerID: containerID,
+		NetNS:       netNs.GetPath(),
+		IfName:      "eth0",
+	}
+
+	_, err = cniConfig.AddNetworkList(namespaceCtx, cniNetworkList, cniRuntimeConf)
 	if err != nil {
 		return "", fmt.Errorf("failed to add CNI network list: %w", err)
 	}
+
+	// Clean up CNI on error to release IP address
+	defer func() {
+		if retErr != nil {
+			if err := cniConfig.DelNetworkList(namespaceCtx, cniNetworkList, cniRuntimeConf); err != nil {
+				log.Warnf("failed to cleanup CNI on error for container %s: %v", containerID, err)
+			}
+		}
+	}()
 
 	task, err := container.NewTask(namespaceCtx, opts.CioCreator)
 	if err != nil {
@@ -301,6 +317,23 @@ func (r *Repo) DeleteContainer(ctx context.Context, containerID string) (uint32,
 	container, err := r.client.LoadContainer(namespaceCtx, containerID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to load container %s: %w", containerID, err)
+	}
+
+	// Get the container spec to find the network namespace path for CNI cleanup
+	spec, err := container.Spec(namespaceCtx)
+	if err != nil {
+		log.WithContext(ctx).Warnf("failed to get spec for container %s: %v", containerID, err)
+	}
+
+	// Find network namespace path from spec
+	var netNsPath string
+	if spec != nil && spec.Linux != nil {
+		for _, ns := range spec.Linux.Namespaces {
+			if ns.Type == "network" && ns.Path != "" {
+				netNsPath = ns.Path
+				break
+			}
+		}
 	}
 
 	task, err := container.Task(namespaceCtx, nil)
@@ -344,9 +377,113 @@ func (r *Repo) DeleteContainer(ctx context.Context, containerID string) (uint32,
 		return 0, fmt.Errorf("failed to delete task: %w", err)
 	}
 
+	// Clean up CNI network to release IP address
+	if netNsPath != "" {
+		ptpConfig := `
+		{
+			"type": "ptp",
+			"ipMasq": true,
+			"ipam": {
+				"type": "host-local",
+				"subnet": "10.88.0.0/16",
+				"resolvConf": "/etc/resolv.conf",
+				"routes": [
+					{ "dst": "0.0.0.0/0" }
+				]
+			}
+		}
+		`
+		firewallConfig := `{"type": "firewall"}`
+
+		cniPlugins := []*libcni.NetworkConfig{
+			{Network: &types.NetConf{Type: "ptp"}, Bytes: []byte(ptpConfig)},
+			{Network: &types.NetConf{Type: "firewall"}, Bytes: []byte(firewallConfig)},
+		}
+
+		cniConfig := libcni.NewCNIConfig([]string{"/opt/hypercore/bin", "/opt/cni/bin"}, nil)
+		if err := cniConfig.DelNetworkList(
+			namespaceCtx, &libcni.NetworkConfigList{
+				Name:       "hypercore-cni",
+				CNIVersion: "0.4.0",
+				Plugins:    cniPlugins,
+			}, &libcni.RuntimeConf{
+				ContainerID: containerID,
+				NetNS:       netNsPath,
+				IfName:      "eth0",
+			},
+		); err != nil {
+			log.WithContext(ctx).Warnf("failed to delete CNI network for container %s: %v", containerID, err)
+			// Don't fail the delete, just log the warning
+		} else {
+			log.WithContext(ctx).Infof("released CNI network resources for container %s", containerID)
+		}
+	} else {
+		log.WithContext(ctx).Warnf("no network namespace path found for container %s, skipping CNI cleanup", containerID)
+	}
+
 	if err := container.Delete(namespaceCtx, containerd.WithSnapshotCleanup); err != nil {
 		return 0, fmt.Errorf("failed to delete container %s: %w", containerID, err)
 	}
 
 	return code, nil
+}
+
+// GarbageCollectCNI cleans up orphaned CNI IP allocations that don't have running containers.
+// This should be called periodically to handle cases where containers crashed without cleanup.
+func (r *Repo) GarbageCollectCNI(ctx context.Context) (int, error) {
+	cniDataDir := "/var/lib/cni/networks/hypercore-cni"
+
+	// Get all running container IDs
+	namespaceCtx := namespaces.WithNamespace(ctx, r.config.ContainerNamespace)
+	tasks, err := r.client.TaskService().List(namespaceCtx, &tasks.ListTasksRequest{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list tasks: %w", err)
+	}
+
+	runningContainers := make(map[string]bool)
+	for _, task := range tasks.GetTasks() {
+		runningContainers[task.GetID()] = true
+	}
+
+	// Scan CNI data directory for IP allocations
+	entries, err := os.ReadDir(cniDataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil // No CNI data, nothing to clean
+		}
+		return 0, fmt.Errorf("failed to read CNI data dir: %w", err)
+	}
+
+	cleaned := 0
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == "last_reserved_ip.0" || entry.Name() == "lock" {
+			continue
+		}
+
+		// Each file is named by IP and contains the container ID
+		ipFile := filepath.Join(cniDataDir, entry.Name())
+		data, err := os.ReadFile(ipFile)
+		if err != nil {
+			continue
+		}
+
+		// File format: container_id\nifname\n...
+		lines := strings.Split(string(data), "\n")
+		if len(lines) == 0 {
+			continue
+		}
+		containerID := strings.TrimSpace(lines[0])
+
+		// If container is not running, remove the allocation
+		if !runningContainers[containerID] {
+			if err := os.Remove(ipFile); err != nil {
+				log.Warnf("failed to remove orphaned CNI allocation %s: %v", entry.Name(), err)
+			} else {
+				log.Infof("cleaned orphaned CNI IP allocation: %s (container: %s)", entry.Name(), containerID)
+				cleaned++
+			}
+		}
+	}
+
+	return cleaned, nil
 }

--- a/pkg/containerd/repo_darwin.go
+++ b/pkg/containerd/repo_darwin.go
@@ -1,0 +1,72 @@
+// +build darwin
+
+package containerd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/api/types/task"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/namespaces"
+)
+
+// Stub implementations for Mac - cluster commands don't need full containerd functionality
+
+type CreateContainerOpts struct {
+	ImageRef    string
+	Snapshotter string
+	Runtime     struct {
+		Name    string
+		Options interface{}
+	}
+	Limits *struct {
+		CPUFraction float64
+		MemoryBytes uint64
+	}
+	Labels     map[string]string
+	CioCreator cio.Creator
+	Env        []string
+}
+
+type Repo struct {
+	client *containerd.Client
+	config *Config
+}
+
+func NewMicroVMRepository(cfg *Config) (*Repo, error) {
+	return nil, fmt.Errorf("containerd operations not supported on Mac - use cluster commands only")
+}
+
+func (r *Repo) CreateContainer(ctx context.Context, opts CreateContainerOpts) (string, error) {
+	return "", fmt.Errorf("containerd operations not supported on Mac")
+}
+
+func (r *Repo) GetContainer(ctx context.Context, id string) (containerd.Container, error) {
+	return nil, fmt.Errorf("containerd operations not supported on Mac")
+}
+
+func (r *Repo) DeleteContainer(ctx context.Context, id string) (uint32, error) {
+	return 0, fmt.Errorf("containerd operations not supported on Mac")
+}
+
+func (r *Repo) GetTasks(ctx context.Context) ([]*task.Process, error) {
+	return nil, fmt.Errorf("containerd operations not supported on Mac")
+}
+
+func (r *Repo) Attach(ctx context.Context, id string) error {
+	return fmt.Errorf("containerd operations not supported on Mac")
+}
+
+func (r *Repo) GetContainerPrimaryIP(ctx context.Context, id string) (string, error) {
+	return "", fmt.Errorf("containerd operations not supported on Mac")
+}
+
+func (r *Repo) GetContext(ctx context.Context) context.Context {
+	return namespaces.WithNamespace(ctx, r.config.ContainerNamespace)
+}
+
+func (r *Repo) GarbageCollectCNI(ctx context.Context) (int, error) {
+	return 0, nil // No-op on Mac
+}

--- a/pkg/shim/shim.go
+++ b/pkg/shim/shim.go
@@ -1,3 +1,6 @@
+// +build !darwin
+// +build linux
+
 package shim
 
 import (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes container networking behavior (CNI subnet and teardown/GC) and adds automated cleanup that could affect running workloads if misapplied; plus a new deployment image/entrypoint that writes auth config and disables device auth.
> 
> **Overview**
> Adds a new `deployments/moltbot-cloud` Docker image that builds the Node/pnpm project into a tarball, installs it globally, and starts `moltbot gateway` via an entrypoint that generates/writes `~/.clawdbot/moltbot.json` (token auth, LAN bind, default model) and optionally writes `auth-profiles.json` from `ANTHROPIC_API_KEY`.
> 
> Updates the containerd repo and cluster agent to reduce leaked CNI IP allocations: switches the CNI subnet to `10.88.0.0/16`, ensures CNI teardown runs on `CreateContainer` errors and during `DeleteContainer`, and adds periodic CNI garbage collection (scanning `/var/lib/cni/networks/hypercore-cni`) triggered from `monitorWorkloads`; also adds Linux/Darwin build separation with a Mac stub repo and Linux-only shim/containerd files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf2e51e31127eac296e835194995d0b664525959. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->